### PR TITLE
Add CI workflow to publish package to npm on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write # the publish action commits the version bump back to the default branch
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run build
+        run: pnpm build
+
+      # Pinned to the v2.0.0 commit SHA (third-party action) for supply-chain safety.
+      - name: Publish to npm
+        uses: simenandre/publish-with-pnpm@d1c054e288970d151b70e430a316cc7d62cf08c5 # v2.0.0
+        with:
+          npm-auth-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What changed

Adds `.github/workflows/release.yaml` — a workflow triggered when a GitHub Release is published. It builds the package and publishes it to npm using the [`publish-with-pnpm`](https://github.com/simenandre/publish-with-pnpm) action.

Steps: checkout → set up pnpm → Node 22.x (with `registry-url` for npm auth) → `pnpm install --frozen-lockfile` → `pnpm build` → publish.

## Why

Publishing to npm was previously a fully manual process (hand-edited version bumps committed directly, e.g. the `v0.2.0` commit). This automates it: cut a GitHub Release with a tag like `v0.3.0`, and CI reads the version from the tag, writes it into `package.json`, publishes, and commits the bump back to the default branch.

## Reviewer notes

- **Third-party action pinned to a commit SHA** (`d1c054e…` = v2.0.0) rather than the floating `@v2` tag, for supply-chain safety.
- **`contents: write`** permission is granted because the action pushes the version-bump commit back to `main`. If `main` is protected, the push may be rejected — the Actions bot would need bypass, or a PAT for checkout.
- **Prerequisite:** an `NPM_TOKEN` repository secret must be added (an npm *automation* token, which works with 2FA) before the first release.
- **Provenance** was intentionally left out: this action runs `pnpm publish` internally and I couldn't confirm it forwards `--provenance`, so `id-token: write` alone wouldn't produce an attestation. A plain `pnpm publish --provenance` step would be the cleaner route if we want it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)