### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-duplicates",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A TypeScript npm package for finding near duplicate string pairs",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## What

Bump the package version from `0.2.2` to `0.2.3` in `package.json`.

## Why

Prepare a new patch release. This follows the repository's established convention of releasing each version bump as its own PR (e.g. [#25](https://github.com/jimexist/near-duplicates/pull/25) "Bump version to 0.2.1").

## Notes for reviewers

- Single-line change to the `version` field in `package.json`.
- The version is not referenced anywhere else (the pnpm lockfile does not track the root package version), so no other files needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)